### PR TITLE
Add node selector support

### DIFF
--- a/docs/design/api-spec.adoc
+++ b/docs/design/api-spec.adoc
@@ -100,6 +100,7 @@ The AerospikeClusterSpec type specifies the desired state of an Aerospike cluste
 | namespaces | The specification of the Aerospike namespaces in the cluster. Must have exactly one element footnote:[Even though the `.spec.namespaces` field must have exactly one element, it was decided to make it an array in order to allow extensibility of the API in the future.]. | <<aerospikenamespacespec,[]AerospikeNamespaceSpec>> | true
 | backupSpec | The specification of how Aerospike namespace backups made by aerospike-operator should be performed and stored. It is only required to be present if one wants to perform version upgrades on the Aerospike cluster. | <<aerospikebackupspec,AerospikeBackupSpec>> | false
 | resources | Standard requests and limits for Server Aerospike Container. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#resourcerequirements-v1-core[v1.ResourceRequirements] | false
+| nodeSelector | Standard node selectors for Server Aerospike Pods. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#nodeselector-v1-core | false
 |===
 
 ==== Validations

--- a/docs/design/api-spec.adoc
+++ b/docs/design/api-spec.adoc
@@ -100,7 +100,7 @@ The AerospikeClusterSpec type specifies the desired state of an Aerospike cluste
 | namespaces | The specification of the Aerospike namespaces in the cluster. Must have exactly one element footnote:[Even though the `.spec.namespaces` field must have exactly one element, it was decided to make it an array in order to allow extensibility of the API in the future.]. | <<aerospikenamespacespec,[]AerospikeNamespaceSpec>> | true
 | backupSpec | The specification of how Aerospike namespace backups made by aerospike-operator should be performed and stored. It is only required to be present if one wants to perform version upgrades on the Aerospike cluster. | <<aerospikebackupspec,AerospikeBackupSpec>> | false
 | resources | Standard requests and limits for Server Aerospike Container. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#resourcerequirements-v1-core[v1.ResourceRequirements] | false
-| nodeSelector | Standard node selectors for Server Aerospike Pods. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#nodeselector-v1-core | false
+| nodeSelector | Standard node selectors for Server Aerospike Pods. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#nodeselector-v1-core[v1.NodeSelector] | false
 |===
 
 ==== Validations

--- a/docs/examples/23-aerospike-cluster-node-selector.yml
+++ b/docs/examples/23-aerospike-cluster-node-selector.yml
@@ -1,0 +1,17 @@
+apiVersion: aerospike.travelaudience.com/v1alpha2
+kind: AerospikeCluster
+metadata:
+  name: as-cluster-0
+spec:
+  version: "4.2.0.10"
+  nodeCount: 2
+  nodeSelector:
+    app: aerospike
+  namespaces:
+  - name: as-namespace-0
+    replicationFactor: 2
+    memorySize: 1G
+    defaultTTL: 0s
+    storage:
+      type: file
+      size: 1G

--- a/docs/usage/10-managing-clusters.adoc
+++ b/docs/usage/10-managing-clusters.adoc
@@ -285,7 +285,7 @@ IMPORTANT: When deleting and recreating an `AerospikeCluster` using `kubectl rep
 
 == Defining node selector for an Aerospike cluster
 
-One may need to make sure that pods in an Aerospike cluster are scheduled in specific k8s nodes, for that node selectors are available.
+One may need to make sure that pods in an Aerospike cluster are scheduled onto specific Kubernetes nodes. For addressing that, node selectors are available.
 
 To test node selectors one needs to add a label to one of the kubernetes nodes:
 

--- a/docs/usage/10-managing-clusters.adoc
+++ b/docs/usage/10-managing-clusters.adoc
@@ -287,7 +287,7 @@ IMPORTANT: When deleting and recreating an `AerospikeCluster` using `kubectl rep
 
 One may need to make sure that pods in an Aerospike cluster are scheduled onto specific Kubernetes nodes. For addressing that, node selectors are available.
 
-To test node selectors one needs to add a label to one of the kubernetes nodes:
+In order to use node selectors, one needs to label at least one of the Kubernetes nodes in one's cluster:
 
 [source,bash]
 ----

--- a/docs/usage/10-managing-clusters.adoc
+++ b/docs/usage/10-managing-clusters.adoc
@@ -282,3 +282,41 @@ IMPORTANT: Deleting an `AerospikeCluster` custom resource will cause all nodes a
 IMPORTANT: When deleting an `AerospikeCluster` using `kubectl delete` one **MUST** make sure that the value of the `--cascade` flag is set to `true`. This is the default value for this command, and **MUST NOT** be changed. Running `kubectl delete --cascade=false` against an `AerospikeCluster`  resource will cause existing dependent resources (pods, services, etc...) to be left untouched (i.e. _orphaned_), requiring manual cleanup by an operator to be deleted from the Kubernetes cluster.
 
 IMPORTANT: When deleting and recreating an `AerospikeCluster` using `kubectl replace --force` one **MUST** make sure that the value of the `--cascade` flag is set to `true`. This is **NOT** the default value for this command, and **MUST be explicitly set**. Running `kubectl replace --force` without `--cascade=true` against an `AerospikeCluster` resource will cause existing dependent resources (pods, services, etc...) to be left untouched (i.e. _orphaned_), requiring manual cleanup by an operator to be deleted from the Kubernetes cluster.
+
+== Defining node selector for an Aerospike cluster
+
+One may need to make sure that pods in an Aerospike cluster are scheduled in specific k8s nodes, for that node selectors are available.
+
+To test node selectors one needs to add a label to one of the kubernetes nodes:
+
+[source,bash]
+----
+$ kubectl label nodes <node-name> app=aerospike
+node "<node-name>" labeled
+----
+
+To define a node selector for an Aerospike cluster one needs to add `node selector` property to `AerospikeCluster` custom resource:
+
+[source,bash]
+----
+$ kubectl create -f - <<EOF
+apiVersion: aerospike.travelaudience.com/v1alpha2
+kind: AerospikeCluster
+metadata:
+  name: as-cluster-0
+spec:
+  version: "4.2.0.10"
+  nodeCount: 1
+  nodeSelector:
+    app: aerospike
+  namespaces:
+  - name: as-namespace-0
+    replicationFactor: 1
+    memorySize: 1G
+    defaultTTL: 0s
+    storage:
+      type: file
+      size: 1G
+EOF
+aerospikecluster.aerospike.travelaudience.com "as-cluster-0" created
+----

--- a/docs/usage/10-managing-clusters.adoc
+++ b/docs/usage/10-managing-clusters.adoc
@@ -295,7 +295,7 @@ $ kubectl label nodes <node-name> app=aerospike
 node "<node-name>" labeled
 ----
 
-To define a node selector for an Aerospike cluster one needs to add `node selector` property to `AerospikeCluster` custom resource:
+In order to define a node selector for an Aerospike cluster, one sets `AerospikeCluster.spec.nodeSelector` property to match the node label set before:
 
 [source,bash]
 ----

--- a/hack/skaffold/e2e/aerospike-operator-e2e.yaml
+++ b/hack/skaffold/e2e/aerospike-operator-e2e.yaml
@@ -18,6 +18,7 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
+  - nodes
   verbs:
   - get
   - list

--- a/pkg/apis/aerospike/v1alpha2/cluster.go
+++ b/pkg/apis/aerospike/v1alpha2/cluster.go
@@ -53,6 +53,8 @@ type AerospikeClusterSpec struct {
 	BackupSpec *AerospikeClusterBackupSpec `json:"backupSpec,omitempty"`
 	// Define resources requests and limits for Aerospike Server Container.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Define which Nodes the Pods are scheduled on.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // AerospikeClusterStatus represents the current state of an Aerospike cluster.

--- a/pkg/reconciler/pod.go
+++ b/pkg/reconciler/pod.go
@@ -378,6 +378,7 @@ func (r *AerospikeClusterReconciler) createPodWithIndex(aerospikeCluster *aerosp
 			Hostname: podName,
 			// use the cluster's name as the subdomain
 			Subdomain: aerospikeCluster.Name,
+			NodeSelector: aerospikeCluster.Spec.NodeSelector,
 		},
 	}
 

--- a/test/e2e/cluster/e2e.go
+++ b/test/e2e/cluster/e2e.go
@@ -145,5 +145,11 @@ var _ = Describe("AerospikeCluster", func() {
 		It("supports setting data-in-memory for a namespace", func() {
 			testDataInMemory(tf, ns)
 		})
+		It("create with node selector", func() {
+			testCreateAerospikeWithNodeSelector(tf, ns)
+		})
+		It("create with invalid node selector", func() {
+			testCreateAerospikeWithInvalidNodeSelector(tf, ns)
+		})
 	})
 })

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -109,13 +109,17 @@ func (tf *TestFramework) WaitForClusterCondition(aerospikeCluster *aerospikev1al
 	return nil
 }
 
-func (tf *TestFramework) WaitForClusterNodeCount(aerospikeCluster *aerospikev1alpha2.AerospikeCluster, nodeCount int32) error {
+func (tf *TestFramework) WaitForClusterNodeCountOrTimeout(aerospikeCluster *aerospikev1alpha2.AerospikeCluster, nodeCount int32, timeout time.Duration) error {
 	return tf.WaitForClusterCondition(aerospikeCluster, func(event watchapi.Event) (bool, error) {
 		// grab the current cluster object from the event
 		obj := event.Object.(*aerospikev1alpha2.AerospikeCluster)
 		// search for the current node count
 		return obj.Status.NodeCount == nodeCount, nil
-	}, watchTimeout)
+	}, timeout)
+}
+
+func (tf *TestFramework) WaitForClusterNodeCount(aerospikeCluster *aerospikev1alpha2.AerospikeCluster, nodeCount int32) error {
+	return tf.WaitForClusterNodeCountOrTimeout(aerospikeCluster, nodeCount, watchTimeout)
 }
 
 func (tf *TestFramework) ScaleCluster(aerospikeCluster *aerospikev1alpha2.AerospikeCluster, nodeCount int32) error {


### PR DESCRIPTION
**Motivation**
At the moment it is not possible to setup node selector for Aerospike pods. Aerospike is a stateful application with special storage, memory and cpu needs. Mainly for that reason we would like to be able to select special nodes to be used by a cluster

**Proposal**
Allow user to define node selector. 

_Example_ 
```yaml
----
apiVersion: aerospike.travelaudience.com/v1alpha2
kind: AerospikeCluster
metadata:
  name: example-aerospike-cluster
  namespace: example-namespace
spec:
  version: "4.2.0.3"
  nodeCount: 3
  nodeSelector:
    app: aerospike
  backupSpec:
      storage:
        type: gcs
        bucket: test-bucket
        secret: bucket-secret
  namespaces:
  - name: as-namespace-0
    replicationFactor: 2
    memorySize: 4G
    defaultTTL: 0s
    storage:
      type: file
      size: 150G
----
```