### PR TITLE
Add tolerations support

### DIFF
--- a/docs/design/api-spec.adoc
+++ b/docs/design/api-spec.adoc
@@ -101,6 +101,7 @@ The AerospikeClusterSpec type specifies the desired state of an Aerospike cluste
 | backupSpec | The specification of how Aerospike namespace backups made by aerospike-operator should be performed and stored. It is only required to be present if one wants to perform version upgrades on the Aerospike cluster. | <<aerospikebackupspec,AerospikeBackupSpec>> | false
 | resources | Standard requests and limits for Server Aerospike Container. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#resourcerequirements-v1-core[v1.ResourceRequirements] | false
 | nodeSelector | Standard node selectors for Server Aerospike Pods. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#nodeselector-v1-core[v1.NodeSelector] | false
+| tolerations | Standard tolerations for Aerospike Pods. | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#toleration-v1-core[v1.Tolerations] | false
 |===
 
 ==== Validations

--- a/docs/examples/23-aerospike-cluster-tolerations.yml
+++ b/docs/examples/23-aerospike-cluster-tolerations.yml
@@ -1,0 +1,19 @@
+apiVersion: aerospike.travelaudience.com/v1alpha2
+kind: AerospikeCluster
+metadata:
+  name: as-cluster-0
+spec:
+  version: "4.2.0.10"
+  nodeCount: 2
+  tolerations:
+  - key: "node.kubernetes.io/memory-pressure"
+    operator: "Exists"
+    effect: "NoSchedule"
+  namespaces:
+  - name: as-namespace-0
+    replicationFactor: 2
+    memorySize: 1G
+    defaultTTL: 0s
+    storage:
+      type: file
+      size: 1G

--- a/docs/usage/10-managing-clusters.adoc
+++ b/docs/usage/10-managing-clusters.adoc
@@ -320,3 +320,33 @@ spec:
 EOF
 aerospikecluster.aerospike.travelaudience.com "as-cluster-0" created
 ----
+
+== Defining tolerations for an Aerospike cluster
+
+To define tolerations for an Aerospike cluster one needs to add `tolerations` property to `AerospikeCluster` custom resource:
+
+[source,bash]
+----
+$ kubectl create -f - <<EOF
+apiVersion: aerospike.travelaudience.com/v1alpha2
+kind: AerospikeCluster
+metadata:
+  name: as-cluster-0
+spec:
+  version: "4.2.0.10"
+  nodeCount: 2
+  tolerations:
+  - key: "node.kubernetes.io/memory-pressure"
+    operator: "Exists"
+    effect: "NoSchedule"
+  namespaces:
+  - name: as-namespace-0
+    replicationFactor: 2
+    memorySize: 1G
+    defaultTTL: 0s
+    storage:
+      type: file
+      size: 1G
+EOF
+aerospikecluster.aerospike.travelaudience.com "as-cluster-0" created
+----

--- a/docs/usage/10-managing-clusters.adoc
+++ b/docs/usage/10-managing-clusters.adoc
@@ -323,7 +323,7 @@ aerospikecluster.aerospike.travelaudience.com "as-cluster-0" created
 
 == Defining tolerations for an Aerospike cluster
 
-To define tolerations for an Aerospike cluster one needs to add `tolerations` property to `AerospikeCluster` custom resource:
+In order to define tolerations for an Aerospike cluster, one sets `AerospikeCluster.spec.tolerations` property:
 
 [source,bash]
 ----

--- a/pkg/apis/aerospike/v1alpha2/cluster.go
+++ b/pkg/apis/aerospike/v1alpha2/cluster.go
@@ -55,6 +55,8 @@ type AerospikeClusterSpec struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Define which Nodes the Pods are scheduled on.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// If specified, the pod's tolerations.
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // AerospikeClusterStatus represents the current state of an Aerospike cluster.

--- a/pkg/reconciler/pod.go
+++ b/pkg/reconciler/pod.go
@@ -379,6 +379,7 @@ func (r *AerospikeClusterReconciler) createPodWithIndex(aerospikeCluster *aerosp
 			// use the cluster's name as the subdomain
 			Subdomain: aerospikeCluster.Name,
 			NodeSelector: aerospikeCluster.Spec.NodeSelector,
+			Tolerations: aerospikeCluster.Spec.Tolerations,
 		},
 	}
 

--- a/test/e2e/cluster/e2e.go
+++ b/test/e2e/cluster/e2e.go
@@ -151,5 +151,8 @@ var _ = Describe("AerospikeCluster", func() {
 		It("create with invalid node selector", func() {
 			testCreateAerospikeWithInvalidNodeSelector(tf, ns)
 		})
+		It("support setting up tolerations for pods", func() {
+			testCreateAerospikeWithTolerations(tf, ns)
+		})
 	})
 })


### PR DESCRIPTION
**Motivation**
At the moment it is not possible to setup tolerations for Aerospike pods. Aerospike is a stateful application with special storage, memory and cpu needs. Mainly for that reason we would like to be able to allow it to go to special nodes in the k8s cluster.

**Proposal**
Allow user to define tolerations. 

_Example_ 
```yaml
----
apiVersion: aerospike.travelaudience.com/v1alpha2
kind: AerospikeCluster
metadata:
  name: example-aerospike-cluster
  namespace: example-namespace
spec:
  version: "4.2.0.3"
  nodeCount: 3
  tolerations:
  - key: "aerospike"
    operator: "Exists"
    effect: "NoSchedule"
  backupSpec:
      storage:
        type: gcs
        bucket: test-bucket
        secret: bucket-secret
  namespaces:
  - name: as-namespace-0
    replicationFactor: 2
    memorySize: 4G
    defaultTTL: 0s
    storage:
      type: file
      size: 150G
----
```