### PR TITLE
Properly handle pods in Error state after initialisation

### DIFF
--- a/hack/skaffold/e2e/aerospike-operator-e2e.yaml
+++ b/hack/skaffold/e2e/aerospike-operator-e2e.yaml
@@ -55,6 +55,11 @@ rules:
   - create
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/e2e/cluster/e2e.go
+++ b/test/e2e/cluster/e2e.go
@@ -154,5 +154,8 @@ var _ = Describe("AerospikeCluster", func() {
 		It("support setting up tolerations for pods", func() {
 			testCreateAerospikeWithTolerations(tf, ns)
 		})
+		It("should recover after pod failure", func() {
+			testAerospikeNodeFail(tf, ns)
+		})
 	})
 })

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 
 	aerospikeclientset "github.com/travelaudience/aerospike-operator/pkg/client/clientset/versioned"
 )
@@ -32,6 +33,7 @@ const (
 type TestFramework struct {
 	AerospikeClient *aerospikeclientset.Clientset
 	KubeClient      *kubernetes.Clientset
+	RestConfig      *rest.Config
 }
 
 func NewTestFramework(kubeconfigPath string) (*TestFramework, error) {
@@ -50,5 +52,6 @@ func NewTestFramework(kubeconfigPath string) (*TestFramework, error) {
 	return &TestFramework{
 		AerospikeClient: aerospikeClient,
 		KubeClient:      kubeClient,
+		RestConfig:		 cfg,
 	}, nil
 }

--- a/test/e2e/framework/pod.go
+++ b/test/e2e/framework/pod.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The aerospike-operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"bytes"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+func (tf *TestFramework) ExecInContainer(pod corev1.Pod, ns *corev1.Namespace, command []string, container string) error {
+	req := tf.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(ns.Name).
+		SubResource("exec")
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Command:   command,
+		Container: container,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(tf.RestConfig, http.MethodPost, req.URL())
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
**Proposal**
Before we were handling pod related checks and cluster related checks in the same loop. My proposal is separate that in order to fix #12. 

_Explanation_
It looks that for each pod AS operator is validating cluster size both in k8s and in Aerospike. For the scenario described in #12 the validation is failing. This fail happens for AS pod with index 1 in first place, so the operator decides to kill that pod to try to fix cluster size problem. However, since it is happening because one of the other AS pods is in Error state, AS operator start the erroneous loop described in #12.
The idea around this PR is to separate AS pod checks from AS cluster checks. So, every pod is checked first. After that the state of the AS cluster for every AS pod is checked.