### PR TITLE
fix binary dynamicaly linked

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -19,10 +19,11 @@ RUN CGO_ENABLED=0 go build \
 
 FROM aerospike/aerospike-tools:8.1.0 AS astools
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/cc
 USER 65532:65532
 COPY --from=builder /asinit /usr/local/bin/asinit
 COPY --from=builder /asprom /usr/local/bin/asprom
 COPY --from=builder /backup /usr/local/bin/backup
-COPY --from=astools /usr/bin/asbackup /usr/local/bin/asbackup
-COPY --from=astools /usr/bin/asrestore /usr/local/bin/asrestore
+COPY --from=astools --chown=0:0 /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=astools --chown=0:0 /usr/bin/asbackup /usr/local/bin/asbackup
+COPY --from=astools --chown=0:0 /usr/bin/asrestore /usr/local/bin/asrestore


### PR DESCRIPTION
Working on asbackup, I realized the version in the new image was not working.
Indeed binary from aerospike/aerospike-tools:8.1.0 are dynamically linked and so cannot be used in gcr.io/distroless/static. So we should use instead gcr.io/distroless/cc.
I also need to add lib /lib/x86_64-linux-gnu/libz.so.1which was missing.