### PR TITLE
DEVOPS-3012: Update ta-docker orb to 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   ta-go: travelaudience/go@0.9
   ta-helm: travelaudience/helm@0.2
-  ta-docker: travelaudience/docker@2.1
+  ta-docker: travelaudience/docker@3.2
   ta-deploy: travelaudience/deploy@0.3
 
 # Defining a top level executor (docker image) with the needed ENV variables


### PR DESCRIPTION
DEVOPS-3012: Since CircleCI is deprecating deploy steps in favor of run steps, we need to update our workflows (and their dependencies) accordingly. More information can be found here: https://circleci.com/docs/migrate-from-deploy-to-run/